### PR TITLE
revoke esri write access to content bucket

### DIFF
--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -66,9 +66,7 @@ Resources:
             Statement:
               - Effect: Allow
                 Action: s3:PutObject
-                Resource:
-                  - !Sub "${ContentBucket.Arn}/esri/*"
-                  - !Sub "${LogBucket.Arn}/esri/*"
+                Resource: !Sub "${LogBucket.Arn}/esri/*"
 
   AccessKey:
     Type: AWS::IAM::AccessKey


### PR DESCRIPTION
Per conversation with David, write access to the content bucket is only needed for whoever is running MDCS to generate the mosaic data set and upload the corresponding `.crf` files to the bucket.  At that moment that will be Heidi.  This revokes ESRI write access to the content bucket.  They will still have write access to the log bucket to deliver server logs.

It's possible MDCS will eventually be automated under ESRI control, in which case we'd need to re-grant these permissions.