### PR TITLE
Replace single Date field with StartDate and EndDate

### DIFF
--- a/image_server/nasa_disasters/Parameter/Config/disasters_mosaics_comp.xml
+++ b/image_server/nasa_disasters/Parameter/Config/disasters_mosaics_comp.xml
@@ -72,6 +72,7 @@
               <name>StartDate</name>
               <type>date</type>
               <length></length>
+            </Field>
             <Field>
               <name>EndDate</name>
               <type>date</type>

--- a/image_server/nasa_disasters/Parameter/Config/disasters_mosaics_comp.xml
+++ b/image_server/nasa_disasters/Parameter/Config/disasters_mosaics_comp.xml
@@ -43,7 +43,7 @@
         <default_mensuration_capabilities>BASIC</default_mensuration_capabilities>
         <allowed_mosaic_methods>Center;NorthWest;Nadir;LockRaster;ByAttribute;Seamline;None</allowed_mosaic_methods>
         <default_mosaic_method>ByAttribute</default_mosaic_method>
-        <order_field>Date</order_field>
+        <order_field>StartDate</order_field>
         <order_base>1/1/2050 12:00:00 AM</order_base>
         <sorting_order>Ascending</sorting_order>
         <mosaic_operator>FIRST</mosaic_operator>
@@ -54,10 +54,10 @@
         <cell_size_tolerance>1.8</cell_size_tolerance>
         <cell_size>3</cell_size>
         <metadata_level>BASIC</metadata_level>
-        <transmission_fields>Name;MinPS;MaxPS;LowPS;HighPS;Date;ZOrder;Dataset_ID;CenterX;CenterY;Tag;ProductName;GroupName</transmission_fields>
+        <transmission_fields>Name;MinPS;MaxPS;LowPS;HighPS;StartDate;EndDate;ZOrder;Dataset_ID;CenterX;CenterY;Tag;ProductName;GroupName</transmission_fields>
         <use_time>ENABLED</use_time>
-        <start_time_field>Date</start_time_field>
-        <end_time_field>#</end_time_field>
+        <start_time_field>StartDate</start_time_field>
+        <end_time_field>EndDate</end_time_field>
         <time_format>#</time_format>
         <geographic_transform>#</geographic_transform>
         <max_num_of_download_items>50</max_num_of_download_items>
@@ -69,7 +69,11 @@
           <AddFields>AddFields</AddFields>
           <Fields>
             <Field>
-              <name>Date</name>
+              <name>StartDate</name>
+              <type>date</type>
+              <length></length>
+            <Field>
+              <name>EndDate</name>
               <type>date</type>
               <length></length>
             </Field>
@@ -80,7 +84,13 @@
           <CalculateValue>
 			  		  <expression_type>PYTHON</expression_type>
                    <!-- NOTE: Set expression_type to PYTHON explicitly for 64 bit systems -->
-              <fieldName>Date</fieldName>
+              <fieldName>StartDate</fieldName>
+              <expression>(!Name!.split("_")[2][4:6] + "/" + !Name!.split("_")[2][6:8] + "/" + !Name!.split("_")[2][:4] + " " + !Name!.split("_")[2][9:11] + ":" + !Name!.split("_")[2][11:13] + ":" + !Name!.split("_")[2][13:15])</expression>
+          </CalculateValue>
+          <CalculateValue>
+			  		  <expression_type>PYTHON</expression_type>
+                   <!-- NOTE: Set expression_type to PYTHON explicitly for 64 bit systems -->
+              <fieldName>EndDate</fieldName>
               <expression>(!Name!.split("_")[2][4:6] + "/" + !Name!.split("_")[2][6:8] + "/" + !Name!.split("_")[2][:4] + " " + !Name!.split("_")[2][9:11] + ":" + !Name!.split("_")[2][11:13] + ":" + !Name!.split("_")[2][13:15])</expression>
           </CalculateValue>
 		  <CalculateValue>

--- a/image_server/nasa_disasters/Parameter/Config/disasters_mosaics_s1.xml
+++ b/image_server/nasa_disasters/Parameter/Config/disasters_mosaics_s1.xml
@@ -43,7 +43,7 @@
         <default_mensuration_capabilities>BASIC</default_mensuration_capabilities>
         <allowed_mosaic_methods>Center;NorthWest;Nadir;LockRaster;ByAttribute;Seamline;None</allowed_mosaic_methods>
         <default_mosaic_method>ByAttribute</default_mosaic_method>
-        <order_field>Date</order_field>
+        <order_field>StartDate</order_field>
         <order_base>2050/01/01</order_base>
         <sorting_order>Ascending</sorting_order>
         <mosaic_operator>FIRST</mosaic_operator>
@@ -54,10 +54,10 @@
         <cell_size_tolerance>1.8</cell_size_tolerance>
         <cell_size>3</cell_size>
         <metadata_level>BASIC</metadata_level>
-        <transmission_fields>Name;MinPS;MaxPS;LowPS;HighPS;Date;ZOrder;Dataset_ID;CenterX;CenterY;Tag;ProductName;GroupName</transmission_fields>
+        <transmission_fields>Name;MinPS;MaxPS;LowPS;HighPS;StartDate;EndDate;ZOrder;Dataset_ID;CenterX;CenterY;Tag;ProductName;GroupName</transmission_fields>
         <use_time>ENABLED</use_time>
-        <start_time_field>Date</start_time_field>
-        <end_time_field>#</end_time_field>
+        <start_time_field>StartDate</start_time_field>
+        <end_time_field>EndDate</end_time_field>
         <time_format>#</time_format>
         <geographic_transform>#</geographic_transform>
         <max_num_of_download_items>50</max_num_of_download_items>
@@ -69,7 +69,12 @@
           <AddFields>AddFields</AddFields>
           <Fields>
             <Field>
-              <name>Date</name>
+              <name>StartDate</name>
+              <type>date</type>
+              <length></length>
+            </Field>
+            <Field>
+              <name>EndDate</name>
               <type>date</type>
               <length></length>
             </Field>
@@ -80,7 +85,13 @@
           <CalculateValue>
 			  		  <expression_type>PYTHON</expression_type>
                    <!-- NOTE: Set expression_type to PYTHON explicitly for 64 bit systems -->
-              <fieldName>Date</fieldName>
+              <fieldName>StartDate</fieldName>
+              <expression>(!Name!.split("_")[2][4:6] + "/" + !Name!.split("_")[2][6:8] + "/" + !Name!.split("_")[2][:4] + " " + !Name!.split("_")[2][9:11] + ":" + !Name!.split("_")[2][11:13] + ":" + !Name!.split("_")[2][13:15])</expression>
+          </CalculateValue>
+          <CalculateValue>
+			  		  <expression_type>PYTHON</expression_type>
+                   <!-- NOTE: Set expression_type to PYTHON explicitly for 64 bit systems -->
+              <fieldName>EndDate</fieldName>
               <expression>(!Name!.split("_")[2][4:6] + "/" + !Name!.split("_")[2][6:8] + "/" + !Name!.split("_")[2][:4] + " " + !Name!.split("_")[2][9:11] + ":" + !Name!.split("_")[2][11:13] + ":" + !Name!.split("_")[2][13:15])</expression>
           </CalculateValue>
 		  <CalculateValue>

--- a/image_server/nasa_disasters/scripts/MDCS_UC.py
+++ b/image_server/nasa_disasters/scripts/MDCS_UC.py
@@ -138,16 +138,21 @@ class UserCode:
         workspace = data['workspace']
         md = data['mosaicdataset']
         ds = os.path.join(workspace, md)
-        ds_cursor = arcpy.da.UpdateCursor(ds, ["Tag", "MinPS", "Category", "Date"])
+        ds_cursor = arcpy.da.UpdateCursor(ds, ["Tag", "MinPS", "Category", "StartDate", "EndDate"])
         if (ds_cursor is not None):
             log.Message('Updating Overview Field Values..', 0)
             for row in ds_cursor:
                 try:
+                    stdate = min(row[3])
+                    endate = max(row[3])
                     TagField = row[0]
                     if (TagField) == 'Dataset':
                         row[1] = 300
                         row[2] = 2
-                        row[3] = datetime.datetime.utcnow().strftime('%m/%d/%Y %H:%M:%S')
+                        #row[3] = datetime.datetime.utcnow().strftime('%m/%d/%Y %H:%M:%S')
+                        #row[4] = datetime.datetime.utcnow().strftime('%m/%d/%Y %H:%M:%S')
+                        row[3] = stdate
+                        row[4] = endate
                         ds_cursor.updateRow(row)
                         log.Message("Overview fields updated.", 0)
                 except Exception as exp:

--- a/image_server/nasa_disasters/scripts/MDCS_UC.py
+++ b/image_server/nasa_disasters/scripts/MDCS_UC.py
@@ -141,7 +141,7 @@ class UserCode:
         ds_cursor = arcpy.da.UpdateCursor(ds, ["Tag", "MinPS", "Category", "StartDate", "EndDate"])
         stdatelist = []
         if (ds_cursor is not None):
-            log.Message('Updating Overview Field Values..', 0)
+            log.Message('Determining Start and End Dates...', 0)
             # Determine the range of dates in the mosaic dataset
             for row in ds_cursor:
                 if row[0] != 'Dataset':
@@ -151,7 +151,7 @@ class UserCode:
             del ds_cursor
         ds_cursor = arcpy.da.UpdateCursor(ds, ["Tag", "MinPS", "Category", "StartDate", "EndDate"])
         if (ds_cursor is not None):
-            log.Message('Updating Overview Field Values..', 0)
+            log.Message('Updating Overview Field Values...', 0)
             # Populate appropriate fields in the overview row of the attribute table
             for row in ds_cursor:
                 try:
@@ -159,8 +159,8 @@ class UserCode:
                         row[1] = 300
                         row[2] = 2
                         #row[3] = datetime.datetime.utcnow().strftime('%m/%d/%Y %H:%M:%S')
-                        row[3] = stdate
-                        row[4] = endate
+                        row[3] = stdate + datetime.timedelta(hours=-8)
+                        row[4] = endate + datetime.timedelta(hours=8)
                         ds_cursor.updateRow(row)
                         log.Message("Overview fields updated.", 0)
                 except Exception as exp:

--- a/image_server/nasa_disasters/scripts/MDCS_UC.py
+++ b/image_server/nasa_disasters/scripts/MDCS_UC.py
@@ -139,18 +139,26 @@ class UserCode:
         md = data['mosaicdataset']
         ds = os.path.join(workspace, md)
         ds_cursor = arcpy.da.UpdateCursor(ds, ["Tag", "MinPS", "Category", "StartDate", "EndDate"])
+        stdatelist = []
         if (ds_cursor is not None):
             log.Message('Updating Overview Field Values..', 0)
+            # Determine the range of dates in the mosaic dataset
+            for row in ds_cursor:
+                if row[0] != 'Dataset':
+                    stdatelist.append(row[3])
+            stdate = min(stdatelist)
+            endate = max(stdatelist)
+            del ds_cursor
+        ds_cursor = arcpy.da.UpdateCursor(ds, ["Tag", "MinPS", "Category", "StartDate", "EndDate"])
+        if (ds_cursor is not None):
+            log.Message('Updating Overview Field Values..', 0)
+            # Populate appropriate fields in the overview row of the attribute table
             for row in ds_cursor:
                 try:
-                    stdate = min(row[3])
-                    endate = max(row[3])
-                    TagField = row[0]
-                    if (TagField) == 'Dataset':
+                    if row[0] == 'Dataset':
                         row[1] = 300
                         row[2] = 2
                         #row[3] = datetime.datetime.utcnow().strftime('%m/%d/%Y %H:%M:%S')
-                        #row[4] = datetime.datetime.utcnow().strftime('%m/%d/%Y %H:%M:%S')
                         row[3] = stdate
                         row[4] = endate
                         ds_cursor.updateRow(row)


### PR DESCRIPTION
Add and populate StartDate and EndDate fields.

- For primary rasters, these will both be the acquisition dates
- When the overviews are added, the start and end dates will be calculated from the MD: the date of the earliest raster will be the start date and the date of the most recent raster will be the end date.