### PR TITLE
Update bat files to pull additional variables out of command

### DIFF
--- a/image_server/nasa_disasters/Parameter/Config/disasters_mosaics_ovr.xml
+++ b/image_server/nasa_disasters/Parameter/Config/disasters_mosaics_ovr.xml
@@ -108,7 +108,7 @@
         </BuildBoundary>
         <Environment>
           <parallelProcessingFactor>11</parallelProcessingFactor>
-          <cellSize>300</cellSize>
+          <cellSize>900</cellSize>
         </Environment>
         <BuildOverviews>
           <where_clause>#</where_clause>

--- a/image_server/nasa_disasters/Parameter/Config/disasters_mosaics_ovr_rgb.xml
+++ b/image_server/nasa_disasters/Parameter/Config/disasters_mosaics_ovr_rgb.xml
@@ -108,7 +108,7 @@
         </BuildBoundary>
         <Environment>
           <parallelProcessingFactor>11</parallelProcessingFactor>
-          <cellSize>300</cellSize>
+          <cellSize>900</cellSize>
         </Environment>
         <BuildOverviews>
           <where_clause>#</where_clause>

--- a/image_server/nasa_disasters/batchFiles/disasters_mosaics.bat
+++ b/image_server/nasa_disasters/batchFiles/disasters_mosaics.bat
@@ -1,9 +1,12 @@
 set ppath="C:\Program Files\ArcGIS\Pro\bin\Python\envs\arcgispro-py3\python.exe" 
 set mdcspath=C:\Users\hjkristenson\PycharmProjects\hyp3-nasa-disasters\image_server\nasa_disasters
-set gdbwks=C:\Users\ASF\Documents\COVID19\Disasters\Esri\MosaicDatasets\missouri_disasters_mosaics.gdb
+set cachepath=C:\Users\ASF\Documents\COVID19\Disasters\Esri\MosaicDatasets\PixelCache
+
+REM ---------- Set output gdb and source s3 bucket-----
+set gdbwks=C:\Users\ASF\Documents\COVID19\Disasters\Esri\MosaicDatasets\disasters_mosaic.gdb
+set acspath=C:\Users\ASF\Documents\COVID19\Disasters\FloodAreas\NASA_Disasters_AWS.acs\SET_S3_TAG_HERE\
 
 REM ---------- Using ACS File -------------------------
-
-%ppath% %mdcspath%\scripts\MDCS.py -i:%mdcspath%\Parameter\Config\disasters_mosaics_s1.xml -m:%gdbwks%\sar_s1 -s:C:\Users\ASF\Documents\COVID19\Disasters\FloodAreas\NASA_Disasters_AWS.acs\Missouri_UTM\ -p:C:\Users\ASF\Documents\COVID19\Disasters\Esri\MosaicDatasets\PixelCache\$cachelocation -p:USE_PIXEL_CACHE$pixelcache -c:CM+AF+AR+BF+BB+SP+CC+CV
+%ppath% %mdcspath%\scripts\MDCS.py -i:%mdcspath%\Parameter\Config\disasters_mosaics_s1.xml -m:%gdbwks%\sar_s1 -s:%acspath% -p:%cachepath%\$cachelocation -p:USE_PIXEL_CACHE$pixelcache -c:CM+AF+AR+BF+BB+SP+CC+CV
 %ppath% %mdcspath%\scripts\MDCS.py -i:%mdcspath%\Parameter\Config\disasters_mosaics_comp.xml -m:%gdbwks%\sar_comp -s:%gdbwks%\sar_s1 -p:CompositeVV_VH_32.art.xml$art -c:CM+AR+UpdateNameField+BB+SP+CC
 

--- a/image_server/nasa_disasters/batchFiles/disasters_mosaics_rgb.bat
+++ b/image_server/nasa_disasters/batchFiles/disasters_mosaics_rgb.bat
@@ -1,9 +1,10 @@
 set ppath="C:\Program Files\ArcGIS\Pro\bin\Python\envs\arcgispro-py3\python.exe" 
 set mdcspath=C:\Users\hjkristenson\PycharmProjects\hyp3-nasa-disasters\image_server\nasa_disasters
-set gdbwks=C:\Users\ASF\Documents\COVID19\Disasters\Esri\MosaicDatasets\missouri_disasters_mosaics_rgb.gdb
+set cachepath=C:\Users\ASF\Documents\COVID19\Disasters\Esri\MosaicDatasets\PixelCache
+
+REM ---------- Set output gdb and source s3 bucket-----
+set gdbwks=C:\Users\ASF\Documents\COVID19\Disasters\Esri\MosaicDatasets\disasters_mosaic.gdb
+set acspath=C:\Users\ASF\Documents\COVID19\Disasters\FloodAreas\NASA_Disasters_AWS.acs\SET_S3_TAG_HERE\
 
 REM ---------- Using ACS File -------------------------
-
-%ppath% %mdcspath%\scripts\MDCS.py -i:%mdcspath%\Parameter\Config\disasters_mosaics_rgb.xml -m:%gdbwks%\rgb -s:C:\Users\ASF\Documents\COVID19\Disasters\FloodAreas\NASA_Disasters_AWS.acs\Missouri_UTM\ -p:C:\Users\ASF\Documents\COVID19\Disasters\Esri\MosaicDatasets\PixelCache\$cachelocation -p:USE_PIXEL_CACHE$pixelcache -c:CM+AF+AR+BF+BB+SP+CC+CV
-
-
+%ppath% %mdcspath%\scripts\MDCS.py -i:%mdcspath%\Parameter\Config\disasters_mosaics_rgb.xml -m:%gdbwks%\rgb -s:%acspath% -p:%cachepath%\$cachelocation -p:USE_PIXEL_CACHE$pixelcache -c:CM+AF+AR+BF+BB+SP+CC+CV

--- a/image_server/nasa_disasters/batchFiles/disasters_overviews.bat
+++ b/image_server/nasa_disasters/batchFiles/disasters_overviews.bat
@@ -1,7 +1,9 @@
 set ppath="C:\Program Files\ArcGIS\Pro\bin\Python\envs\arcgispro-py3\python.exe" 
 set mdcspath=C:\Users\hjkristenson\PycharmProjects\hyp3-nasa-disasters\image_server\nasa_disasters
-set gdbwks=C:\Users\ASF\Documents\COVID19\Disasters\Esri\MosaicDatasets\missouri_disasters_mosaics.gdb
-set outcrf=C:\Users\ASF\Documents\COVID19\Disasters\FloodAreas\NASA_Disasters_AWS.acs\esri\missouri_disasters_mosaics_sar_comp.crf
+
+REM ---------- Set source gdb and output crf file------
+set gdbwks=C:\Users\ASF\Documents\COVID19\Disasters\Esri\MosaicDatasets\disasters_mosaic.gdb
+set outcrf=C:\Users\ASF\Documents\COVID19\Disasters\FloodAreas\NASA_Disasters_AWS.acs\esri\disasters_mosaic_sar_comp.crf
 
 REM ---------- Using ACS File -------------------------
 

--- a/image_server/nasa_disasters/batchFiles/disasters_overviews_rgb.bat
+++ b/image_server/nasa_disasters/batchFiles/disasters_overviews_rgb.bat
@@ -1,8 +1,9 @@
 set ppath="C:\Program Files\ArcGIS\Pro\bin\Python\envs\arcgispro-py3\python.exe" 
 set mdcspath=C:\Users\hjkristenson\PycharmProjects\hyp3-nasa-disasters\image_server\nasa_disasters
-set gdbwks=C:\Users\ASF\Documents\COVID19\Disasters\Esri\MosaicDatasets\missouri_disasters_mosaics_rgb.gdb
-set outcrf=C:\Users\ASF\Documents\COVID19\Disasters\FloodAreas\NASA_Disasters_AWS.acs\esri\missouri_disasters_mosaics_rgb.crf
+
+REM ---------- Set source gdb and output crf file------
+set gdbwks=C:\Users\ASF\Documents\COVID19\Disasters\Esri\MosaicDatasets\disasters_mosaic.gdb
+set outcrf=C:\Users\ASF\Documents\COVID19\Disasters\FloodAreas\NASA_Disasters_AWS.acs\esri\disasters_mosaic_rgb.crf
 
 REM ---------- Using ACS File -------------------------
-
 %ppath% %mdcspath%\scripts\MDCS.py -i:%mdcspath%\Parameter\Config\disasters_mosaics_ovr_rgb.xml -m:%gdbwks%\rgb -s:%outcrf% -c:SE+CRA+AR+UpdateOverviewFields -p:%outcrf%$outcrf


### PR DESCRIPTION
1. There were a few items that were being changed in the actual command line; this brings all the potentially changeable parts to the top to be set as variables to reduce accidental errors if the buried changes are not made.
2. This PR also sets the default cell size for overviews to 900 rather than 300 to reduce the file size/processing time. Because the source rasters are set to display up until 1600, it wasn't necessary for the overviews to be generated starting at such a small pixel size. 