### PR TITLE
add cloudformation template for image server

### DIFF
--- a/update_image_services/image_server_cloudformation.yml
+++ b/update_image_services/image_server_cloudformation.yml
@@ -1,0 +1,168 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Parameters:
+
+  VpcId:
+    Type: AWS::EC2::VPC::Id
+
+  SubnetIds:
+    Type: List<AWS::EC2::Subnet::Id>
+
+  CertificateArn:
+    Type: String
+
+  KeyName:
+    Type: String
+
+  SshCidrIp:
+    Type: String
+
+  Bucket:
+    Type: String
+
+  ImageId:
+    Type: AWS::EC2::Image::Id
+    Default: ami-037b459896b65e4c4
+
+  OverviewPrefix:
+    Type: String
+    Default: overviews/
+
+Resources:
+
+  ImageServerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Sub "Security group for ${AWS::StackName} Image Server"
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          SourceSecurityGroupId: !Ref LoadBalancerSecurityGroup
+          ToPort: 6443
+          FromPort: 6443
+        - IpProtocol: tcp
+          CidrIp: !Ref SshCidrIp
+          ToPort: 22
+          FromPort: 22
+      VpcId: !Ref VpcId
+
+  ImageServerInstance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: !Ref ImageId
+      InstanceType: m5.2xlarge
+      KeyName: !Ref KeyName
+      IamInstanceProfile: !Ref InstanceProfile
+      NetworkInterfaces:
+        - AssociatePublicIpAddress: true
+          DeviceIndex: "0"
+          DeleteOnTermination: true
+          SubnetId: !Select [0, !Ref SubnetIds]
+          GroupSet:
+            - !Ref ImageServerSecurityGroup
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            VolumeType: gp2
+            VolumeSize: 200
+      DisableApiTermination: true
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-image-server"
+
+  LoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Subnets: !Ref SubnetIds
+      SecurityGroups:
+        - !GetAtt LoadBalancerSecurityGroup.GroupId
+
+  HttpListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - Type: redirect
+          RedirectConfig:
+            StatusCode: HTTP_301
+            Protocol: HTTPS
+            Port: 443
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: 80
+      Protocol: HTTP
+
+  HttpsListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref TargetGroup
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: 443
+      Protocol: HTTPS
+      Certificates:
+        - CertificateArn: !Ref CertificateArn
+
+  LoadBalancerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupName: !Sub "${AWS::StackName}-load-balancer"
+      GroupDescription: !Sub "Security group for ${AWS::StackName} load balancer"
+      VpcId: !Ref VpcId
+      SecurityGroupIngress:
+        - CidrIp: 0.0.0.0/0
+          IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+        - CidrIp: 0.0.0.0/0
+          IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+
+  TargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Port: 6443
+      Protocol: HTTPS
+      VpcId: !Ref VpcId
+      Targets:
+        - Id: !Ref ImageServerInstance
+          Port: 6443
+      HealthCheckPath: /
+      HealthCheckIntervalSeconds: 60
+      HealthyThresholdCount: 2
+      Matcher:
+        HttpCode: 200-399
+
+  ServerRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          Action: sts:AssumeRole
+          Principal:
+            Service: ec2.amazonaws.com
+          Effect: Allow
+      Policies:
+        - PolicyName: policy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                - s3:ListBucket
+                - s3:GetBucketAcl
+                Resource: !Sub "arn:aws:s3:::${Bucket}"
+              - Effect: Allow
+                Action:
+                - s3:GetObject
+                - s3:GetObjectVersion
+                Resource: !Sub "arn:aws:s3:::${Bucket}/*"
+              - Effect: Allow
+                Action: s3:PutObject
+                Resource: !Sub "arn:aws:s3:::${Bucket}/${OverviewPrefix}*"
+
+  InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Roles:
+        - !Ref ServerRole


### PR DESCRIPTION
I realized I'd never checked the cloudformation used to deploy gis.asf.alaska.edu into github. All of these components have been deployed for several months, except the `ServerRole` and `InstanceProfile` are new resources to support running the update python script.

I'm still content to deploy this stack manually, rather than building a github action to do it.