### PR TITLE
Add rastertype configuration file for dual-band RTC

### DIFF
--- a/update_image_services/rastertype_rtc_comp_vv_vh.art.xml
+++ b/update_image_services/rastertype_rtc_comp_vv_vh.art.xml
@@ -1,0 +1,189 @@
+<RasterType xsi:type='typens:RasterType' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:xs='http://www.w3.org/2001/XMLSchema' xmlns:typens='http://www.esri.com/schemas/ArcGIS/2.7.0'>
+    <Names xsi:type='typens:ArrayOfString'>
+        <String>RasterBuilder</String>
+        <String>ItemTemplates</String>
+        <String>Name</String>
+        <String>Aliases</String>
+        <String>Version</String>
+        <String>Description</String>
+        <String>InputDataSourceTypes</String>
+        <String>DataSourceFilter</String>
+        <String>SupportsOrthorectification</String>
+        <String>SupportsStereo</String>
+        <String>SupportsSeamline</String>
+        <String>EnableClipToFootprint</String>
+        <String>AllowSimplification</String>
+        <String>IsSensorRasterType</String>
+        <String>SupportsColorCorrection</String>
+        <String>FactoryCLSID</String>
+        <String>SupportedURIFilters</String>
+        <String>Parameters</String>
+        <String>FirstAddTimeStamp</String>
+        <String>FullName</String>
+        <String>AddRastersParameters</String>
+        <String>SynchronizeParameters</String>
+    </Names>
+    <Values xsi:type='typens:ArrayOfAnyType'>
+        <AnyType xsi:type='typens:TableBuilder'>
+            <Names xsi:type='typens:ArrayOfString'>
+                <String>AuxiliaryFields</String>
+                <String>AuxiliaryFieldAlias</String>
+                <String>RasterField</String>
+                <String>NameField</String>
+                <String>GroupField</String>
+                <String>TagField</String>
+                <String>ParentRasterTypeName</String>
+                <String>Properties</String>
+                <String>MergeItems</String>
+            </Names>
+            <Values xsi:type='typens:ArrayOfAnyType'>
+                <AnyType xsi:type='typens:Fields'>
+                    <FieldArray xsi:type='typens:ArrayOfField'></FieldArray>
+                </AnyType>
+                <AnyType xsi:type='typens:PropertySet'>
+                    <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'></PropertyArray>
+                </AnyType>
+                <AnyType xsi:type='xs:string'>Raster</AnyType>
+                <AnyType xsi:type='xs:string'>Name</AnyType>
+                <AnyType xsi:type='xs:string'>GroupName</AnyType>
+                <AnyType xsi:type='xs:string'>Tag</AnyType>
+                <AnyType xsi:type='xs:string'>Table</AnyType>
+                <AnyType xsi:type='typens:PropertySet'>
+                    <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                        <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                            <Key>BandProperties</Key>
+                            <Value xsi:type='typens:ArrayOfArgument'></Value>
+                        </PropertySetProperty>
+                        <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                            <Key>DefaultBandCount</Key>
+                            <Value xsi:type='xs:int'>0</Value>
+                        </PropertySetProperty>
+                        <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                            <Key>EditorDefaultNumBands</Key>
+                            <Value xsi:type='xs:int'>3</Value>
+                        </PropertySetProperty>
+                    </PropertyArray>
+                </AnyType>
+                <AnyType xsi:type='xs:boolean'>false</AnyType>
+            </Values>
+        </AnyType>
+        <AnyType xsi:type='typens:ArrayOfItemTemplate' xmlns:typens='http://www.esri.com/schemas/ArcGIS/10.0'>
+            <ItemTemplate xsi:type='typens:ItemTemplate'>
+                <Name>Default</Name>
+                <Enabled>true</Enabled>
+                <IntersectFootprints>false</IntersectFootprints>
+                <OutputDatasetTag></OutputDatasetTag>
+                <PrimaryInputDatasetTag></PrimaryInputDatasetTag>
+                <FunctionTemplate xsi:type='typens:RasterFunctionTemplate'>
+                    <Name>MS</Name>
+                    <Description>A raster function template.</Description>
+                    <Function xsi:type='typens:CompositeBandFunction'>
+                        <Name>CompositeVV_VH</Name>
+                        <Description>Combines rasters to form a multiband raster.</Description>
+                        <PixelType>UNKNOWN</PixelType>
+                    </Function>
+                    <Arguments xsi:type='typens:RasterFunctionVariable'>
+                        <Name>Rasters_2017419_171057_ 44</Name>
+                        <Description></Description>
+                        <Value xsi:type='typens:ArrayOfArgument'>
+                            <Argument xsi:type='typens:RasterFunctionVariable'>
+                                <Name>VV</Name>
+                                <Description></Description>
+                                <Value></Value>
+                                <IsDataset>true</IsDataset>
+                            </Argument>
+                            <Argument xsi:type='typens:RasterFunctionVariable'>
+                                <Name>VH</Name>
+                                <Description></Description>
+                                <Value></Value>
+                                <IsDataset>true</IsDataset>
+                            </Argument>
+                        </Value>
+                        <IsDataset>false</IsDataset>
+                    </Arguments>
+                    <Help></Help>
+                    <Type>0</Type>
+                    <Thumbnail xsi:type='xs:string'></Thumbnail>
+                    <Definition></Definition>
+                    <Group></Group>
+                    <Tag></Tag>
+                    <ThumbnailEx></ThumbnailEx>
+                    <Properties xsi:type='typens:PropertySet'>
+                        <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                            <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                                <Key>MatchVariable</Key>
+                                <Value xsi:type='typens:RasterFunctionVariable'>
+                                    <Name>MatchVariable</Name>
+                                    <Description></Description>
+                                    <Value xsi:type='xs:int'>1</Value>
+                                    <IsDataset>false</IsDataset>
+                                </Value>
+                            </PropertySetProperty>
+                            <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                                <Key>UnionDimension</Key>
+                                <Value xsi:type='typens:RasterFunctionVariable'>
+                                    <Name>UnionDimension</Name>
+                                    <Description></Description>
+                                    <Value xsi:type='xs:int'>0</Value>
+                                    <IsDataset>false</IsDataset>
+                                </Value>
+                            </PropertySetProperty>
+                        </PropertyArray>
+                    </Properties>
+                </FunctionTemplate>
+                <SupportsEnhancement>false</SupportsEnhancement>
+                <IsEnhancementEnabled>true</IsEnhancementEnabled>
+                <IntersectFootprints>false</IntersectFootprints>
+                <AncillaryDatasets xsi:nil='true'/>
+                <AncillaryFunctionTemplateNames xsi:nil='true'/>
+                <PrimaryChainConnectorVariables xsi:nil='true'/>
+            </ItemTemplate>
+        </AnyType>
+        <AnyType xsi:type='xs:string'>CompositeVV_VH</AnyType>
+        <AnyType xsi:type='typens:ArrayOfString'></AnyType>
+        <AnyType xsi:type='xs:int'>1</AnyType>
+        <AnyType xsi:type='xs:string'>Supports all tables</AnyType>
+        <AnyType xsi:type='xs:int'>176</AnyType>
+        <AnyType xsi:type='xs:string'></AnyType>
+        <AnyType xsi:type='xs:boolean'>false</AnyType>
+        <AnyType xsi:type='xs:boolean'>false</AnyType>
+        <AnyType xsi:type='xs:boolean'>true</AnyType>
+        <AnyType xsi:type='xs:boolean'>true</AnyType>
+        <AnyType xsi:type='xs:boolean'>false</AnyType>
+        <AnyType xsi:type='xs:boolean'>false</AnyType>
+        <AnyType xsi:type='xs:boolean'>true</AnyType>
+        <AnyType xsi:type='typens:UID'>
+            <UID xsi:type='xs:string'>{8F2800F4-5842-47DF-AD1D-2077A7966BBF}</UID>
+        </AnyType>
+        <AnyType xsi:type='typens:ArrayOfArgument'></AnyType>
+        <AnyType xsi:type='typens:PropertySet'>
+            <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'></PropertyArray>
+        </AnyType>
+        <AnyType xsi:type='xs:double'>44230.585406782404</AnyType>
+        <AnyType xsi:type='typens:RasterTypeName'>
+            <Name>CompositeVV_VH</Name>
+            <InstanceID>2</InstanceID>
+            <MosaicDatasetName xsi:type='typens:MosaicDatasetName'>
+                <WorkspaceName xsi:type='typens:WorkspaceName'>
+                    <PathName>c:\abhijit-work\projects\nasa\20210202\v1\MD\test2.gdb</PathName>
+                    <BrowseName>test2</BrowseName>
+                    <WorkspaceFactoryProgID>esriDataSourcesGDB.FileGDBWorkspaceFactory</WorkspaceFactoryProgID>
+                    <WorkspaceType>esriLocalDatabaseWorkspace</WorkspaceType>
+                    <ConnectionProperties xsi:type='typens:PropertySet'>
+                        <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                            <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                                <Key>DATABASE</Key>
+                                <Value xsi:type='xs:string'>c:\abhijit-work\projects\nasa\20210202\v1\MD\test2.gdb</Value>
+                            </PropertySetProperty>
+                        </PropertyArray>
+                    </ConnectionProperties>
+                </WorkspaceName>
+                <Name>sar_comp</Name>
+                <NameString></NameString>
+                <Category>Mosaic Dataset</Category>
+            </MosaicDatasetName>
+        </AnyType>
+        <AnyType xsi:nil='true'/>
+        <AnyType xsi:nil='true'/>
+    </Values>
+</RasterType>


### PR DESCRIPTION
This PR adds a config file to the update_image_server directory for use in combining the single-band VV and VH RTC rasters added to the source mosaic dataset to dual-band images (including VV and VH for each acquisition).