### PR TITLE
allow s3:GetBucketLocation in image server IAM role to support OptimizeRasters.py

### DIFF
--- a/update_image_services/image_server_cloudformation.yml
+++ b/update_image_services/image_server_cloudformation.yml
@@ -151,6 +151,7 @@ Resources:
                 Action:
                 - s3:ListBucket
                 - s3:GetBucketAcl
+                - s3:GetBucketLocation
                 Resource: !Sub "arn:aws:s3:::${Bucket}"
               - Effect: Allow
                 Action:


### PR DESCRIPTION
Initial attempts to run OptimizeRasters.py using input data in S3 fails with `log-warning:get/bucket/region (An error occurred (AccessDenied) when calling the GetBucketLocation operation: Access Denied)`, presumably at https://github.com/Esri/OptimizeRasters/blob/master/OptimizeRasters.py#L3277

I've successfully deployed this change to the `gis-services` stack.