### PR TITLE
Change the today variable so that it uses the date of the following day

### DIFF
--- a/image_server/nasa_disasters_conus/batchFiles/update_hurricanes.py
+++ b/image_server/nasa_disasters_conus/batchFiles/update_hurricanes.py
@@ -2,16 +2,14 @@
 # then runs them in sequence
 
 import os
-from datetime import date, timedelta
+import datetime
 import subprocess
 
 import arcpy
 
 os.chdir(r'C:\Users\hjkristenson\PycharmProjects\hyp3-nasa-disasters\image_server\nasa_disasters_conus\batchFiles')
 
-#today = str(date.today().strftime("%y%m%d"))
-# Because we're now processing in the evening AK time, we'll use the next day's date to tag the updates.
-today = str((date.today()+timedelta(days=1)).strftime("%y%m%d"))
+today = datetime.datetime.now(datetime.timezone.utc).strftime("%y%m%d_%H%M")
 s3tag = 'RTC_services'
 dirtag = 'Hurricanes'
 projtag = 'RTCservices'

--- a/image_server/nasa_disasters_conus/batchFiles/update_hurricanes.py
+++ b/image_server/nasa_disasters_conus/batchFiles/update_hurricanes.py
@@ -4,11 +4,14 @@
 import os
 from datetime import date, timedelta
 import subprocess
+
 import arcpy
 
 os.chdir(r'C:\Users\hjkristenson\PycharmProjects\hyp3-nasa-disasters\image_server\nasa_disasters_conus\batchFiles')
 
-today = str(date.today().strftime("%y%m%d"))
+#today = str(date.today().strftime("%y%m%d")+'B')
+# Because we're now processing in the evening AK time, we'll use the next day's date to tag the updates.
+today = str((date.today()+timedelta(days=1)).strftime("%y%m%d"))
 s3tag = 'RTC_services'
 dirtag = 'Hurricanes'
 projtag = 'RTCservices'

--- a/image_server/nasa_disasters_conus/batchFiles/update_hurricanes.py
+++ b/image_server/nasa_disasters_conus/batchFiles/update_hurricanes.py
@@ -9,7 +9,7 @@ import arcpy
 
 os.chdir(r'C:\Users\hjkristenson\PycharmProjects\hyp3-nasa-disasters\image_server\nasa_disasters_conus\batchFiles')
 
-#today = str(date.today().strftime("%y%m%d")+'B')
+#today = str(date.today().strftime("%y%m%d"))
 # Because we're now processing in the evening AK time, we'll use the next day's date to tag the updates.
 today = str((date.today()+timedelta(days=1)).strftime("%y%m%d"))
 s3tag = 'RTC_services'


### PR DESCRIPTION
The update process starts late in the evening, and I've been generating the date tag so that it uses the next day's date, to indicate that's the most recent update for that day, to align with the 4am updates that we used to do. I hadn't pushed the change to the repo, but that's what's been used functionally for the updates since we went to the 10pm process/transfer schedule. 

This action is just so that the repo reflects what's actually happening currently.