### PR TITLE
Stop processing data for Australia AOI

### DIFF
--- a/.github/workflows/process-and-transfer.yml
+++ b/.github/workflows/process-and-transfer.yml
@@ -24,8 +24,6 @@ jobs:
             config_file: data_management/floods.json
           - environment: PDC Brazil
             config_file: data_management/pdc_brazil.json
-          - environment: NAS Australia
-            config_file: data_management/nas_australia.json
           - environment: Alaska
             config_file: data_management/alaska.json
 

--- a/data_management/nas_australia.json
+++ b/data_management/nas_australia.json
@@ -23,7 +23,7 @@
   },
   "transfer_spec": {
     "target_bucket": "hyp3-nasa-disasters",
-    "target_prefix": "RTC_services",
+    "target_prefix": "Australia",
     "extensions": ["_VV.tif", "_VV.tif.xml", "_VH.tif", "_rgb.tif",  "_dem.tif", "_WM.tif", "_WM_HAND.tif"]
   }
 }


### PR DESCRIPTION
The inclusion of Australia in the RTC image service impacts visualization in the webmap. 
Until we hear from stakeholders, we'll continue to process new data, but keep it in a separate bucket. 