### PR TITLE
Add batch file to use in the Task Scheduler

### DIFF
--- a/image_server/asf_services/batchFiles/schedule_ukraine.bat
+++ b/image_server/asf_services/batchFiles/schedule_ukraine.bat
@@ -1,0 +1,1 @@
+"C:\Program Files\ArcGIS\Pro\bin\Python\envs\arcgispro-py3\python.exe" "C:\Users\hjkristenson\PycharmProjects\hyp3-nasa-disasters\image_server\asf_services\batchFiles\update_ukraine.py"


### PR DESCRIPTION
When a line was added to the existing schedule.bat file in the image_server/nasa_disasters_conus directory to process the Ukraine services, the task scheduler never successfully updated all the services. It's not clear what was going on, but when the line to update the Ukraine services was moved into its own schedule batch file and accessed using a separate Task Scheduler entry, all of the services updated as expected (both CONUS and Ukraine). 