### PR TITLE
update extensions for flood map products

### DIFF
--- a/data_management/hkh_watermaps.json
+++ b/data_management/hkh_watermaps.json
@@ -30,6 +30,6 @@
   "transfer_spec": {
     "target_bucket": "hyp3-nasa-disasters",
     "target_prefix": "HKHwatermaps",
-    "extensions": ["_VV.tif", "_VV.tif.xml", "_VH.tif", "_rgb.tif", "_dem.tif", "_WM.tif", "_WM_HAND.tif", "_WaterDepth.tif", "_FloodMask.tif", "_FloodDepth.tif"]
+    "extensions": ["_VV.tif", "_VV.tif.xml", "_VH.tif", "_rgb.tif", "_dem.tif", "_WM.tif", "_WM_HAND.tif", "_FM_iterative_WaterDepth.tif", "_FM_iterative_FloodMask.tif", "_FM_iterative_FloodDepth.tif"]
   }
 }


### PR DESCRIPTION
The transfer script builds the source key by adding the `extension` to the product name: https://github.com/ASFHyP3/hyp3-nasa-disasters/blob/main/data_management/hyp3_transfer_script.py#L57

Here's what the file names look like:
```
S1A_IW_20220516T120434_DVR_RTC30_G_gpufed_E2FC.zip
S1A_IW_20220516T120434_DVR_RTC30_G_gpufed_E2FC_FM_iterative_FloodDepth.tif
S1A_IW_20220516T120434_DVR_RTC30_G_gpufed_E2FC_FM_iterative_FloodMask.tif
S1A_IW_20220516T120434_DVR_RTC30_G_gpufed_E2FC_FM_iterative_WaterDepth.tif
```

The initial transfer attempt failed because the entire product-specific extension was not provided for the flood map products: https://github.com/ASFHyP3/hyp3-nasa-disasters/runs/6457820483?check_suite_focus=true
Specifically, it looked to copy `S1A_IW_20220516T120434_DVR_RTC30_G_gpufed_E2FC_WaterDepth.tif`, which doesn't exist.