### PR TITLE
update AMI Id and Instance Type for future image server deployments

### DIFF
--- a/update_image_services/image_server_cloudformation.yml
+++ b/update_image_services/image_server_cloudformation.yml
@@ -22,7 +22,11 @@ Parameters:
 
   ImageId:
     Type: AWS::EC2::Image::Id
-    Default: ami-037b459896b65e4c4
+    Default: ami-0b1ddcef10ffe54fb
+
+  InstanceType:
+    Type: string
+    Default: m6i.2xlarge
 
   OverviewPrefix:
     Type: String
@@ -49,7 +53,7 @@ Resources:
     Type: AWS::EC2::Instance
     Properties:
       ImageId: !Ref ImageId
-      InstanceType: m5.2xlarge
+      InstanceType: !Ref InstanceType
       KeyName: !Ref KeyName
       IamInstanceProfile: !Ref InstanceProfile
       NetworkInterfaces:

--- a/update_image_services/image_server_cloudformation.yml
+++ b/update_image_services/image_server_cloudformation.yml
@@ -25,7 +25,7 @@ Parameters:
     Default: ami-0b1ddcef10ffe54fb
 
   InstanceType:
-    Type: string
+    Type: String
     Default: m6i.2xlarge
 
   OverviewPrefix:


### PR DESCRIPTION
The `m6i.2xlarge` instance type is the next generation of the `m5.2xlarge`, same hourly on-demand cost, but should deliver better performance: https://aws.amazon.com/blogs/aws/new-amazon-ec2-m6i-instances-powered-by-the-latest-generation-intel-xeon-scalable-processors/

`ami-0b1ddcef10ffe54fb` is the most recent "Esri ArcGIS Enterprise 10.9.1 on Ubuntu (Apr 2022)" image, where previously we were using the `ami-037b459896b65e4c4` "Esri ArcGIS Enterprise 10.8.1 on Ubuntu (May 2021)" image by default