### PR TITLE
Always try to transfer prodcuts

### DIFF
--- a/.github/workflows/process-and-transfer.yml
+++ b/.github/workflows/process-and-transfer.yml
@@ -52,6 +52,7 @@ jobs:
           environment-file: data_management/environment.yml
 
       - name: Process new granules
+        continue-on-error: true
         shell: bash -l {0}
         run: |
           python data_management/process_new_granules.py -y -w ${{ matrix.config_file }}


### PR DESCRIPTION
For the HKH region, `WATER_MAP` jobs are taking on average 4 hours, but we've seen 10 hours. Generally the `hyp3.watch` will end up hitting the GitHub Actions timeout and fail and not make it to the transfer step. 

This allows the github action step to always also try and transfer products, picking on that have succeded from runs past. 