### PR TITLE
Update for new water map api changes

### DIFF
--- a/data_management/hkh_watermaps.json
+++ b/data_management/hkh_watermaps.json
@@ -12,7 +12,6 @@
   },
   "job_spec": {
     "job_type": "WATER_MAP",
-    "flood_depth_estimator": "iterative",
     "job_parameters": {
       "resolution": 30,
       "speckle_filter": true,
@@ -21,6 +20,7 @@
       "hand_threshold": 15.0,
       "hand_fraction": 0.8,
       "membership_threshold": 0.45,
+      "flood_depth_estimator": "iterative",
       "iterative_max": 15,
       "iterative_min": 0,
       "known_water_threshold": 30,

--- a/data_management/hkh_watermaps.json
+++ b/data_management/hkh_watermaps.json
@@ -12,6 +12,7 @@
   },
   "job_spec": {
     "job_type": "WATER_MAP",
+    "flood_depth_estimator": "iterative",
     "job_parameters": {
       "resolution": 30,
       "speckle_filter": true,
@@ -20,8 +21,6 @@
       "hand_threshold": 15.0,
       "hand_fraction": 0.8,
       "membership_threshold": 0.45,
-      "include_flood_depth": true,
-      "flood_depth_estimator": "iterative",
       "iterative_max": 15,
       "iterative_min": 0,
       "known_water_threshold": 30,


### PR DESCRIPTION
[Water map jobs](https://github.com/ASFHyP3/hyp3/blob/develop/CHANGELOG.md?plain=1#L14) now take one "flood_depth_estimator" job parameter, rather than both "include_flood_depth" True or False and  "flood_depth_estimator" arguments. 