### PR TITLE
do not attempt to transfer RUNNING jobs in hyp3_transfer_script.py

### DIFF
--- a/data_management/hyp3_transfer_script.py
+++ b/data_management/hyp3_transfer_script.py
@@ -50,7 +50,7 @@ def hyp3_transfer_script(config_file: str, prompt: bool = False):
 
     objects_to_copy = []
     project_contents = get_project_contents(target_bucket, target_prefix)
-    for job in jobs.filter_jobs(succeeded=True, include_expired=False):
+    for job in jobs.filter_jobs(succeeded=True, running=False, failed=False, include_expired=False):
         source_bucket = job.files[0]['s3']['bucket']
         zip_key = job.files[0]['s3']['key']
         for ext in config['transfer_spec']['extensions']:


### PR DESCRIPTION
I'd remembered the [filter_jobs](https://github.com/ASFHyP3/hyp3-sdk/blob/develop/src/hyp3_sdk/jobs.py#L254) interface incorrectly. You have to explicitly set succeeded/running/failed to True or False; setting succeeded=True doesn't exclude RUNNING jobs on its own.

The [HKHWatermap] data set has had long-running jobs since we set `flood_depth_estimator=iterative` last month. This would occasionally cause the [process and transfer](https://github.com/ASFHyP3/hyp3-nasa-disasters/actions/runs/4086680086/jobs/7046270927) action to fail when trying to process a still-running job:
```
Looking for new files to copy...
  File "/home/runner/work/hyp3-nasa-disasters/hyp3-nasa-disasters/data_management/hyp3_transfer_script.py", line 82, in <module>
    hyp3_transfer_script(args.config_file, prompt=args.yes)
  File "/home/runner/work/hyp3-nasa-disasters/hyp3-nasa-disasters/data_management/hyp3_transfer_script.py", line 54, in hyp3_transfer_script
    source_bucket = job.files[0]['s3']['bucket']
TypeError: 'NoneType' object is not subscriptable
```