### PR TITLE
drop python 3.8 support

### DIFF
--- a/data_management/environment.yml
+++ b/data_management/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python>=3.8
+  - python>=3.9
   - asf_search
   - boto3
   - hyp3_sdk


### PR DESCRIPTION
TODO:

- [x] Confirm that this is an OK change and does not have implications for any deployed applications; see the README at https://github.com/ASFHyP3/hyp3-nasa-disasters/tree/main/data_management