### PR TITLE
do not wait for jobs to finish

### DIFF
--- a/.github/workflows/process-and-transfer.yml
+++ b/.github/workflows/process-and-transfer.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Process new granules
         shell: bash -l {0}
         run: |
-          python data_management/process_new_granules.py -y -w ${{ matrix.config_file }}
+          python data_management/process_new_granules.py -y ${{ matrix.config_file }}
 
       - name: Transfer new products
         shell: bash -l {0}


### PR DESCRIPTION
See https://github.com/ASFHyP3/hyp3-nasa-disasters/issues/129

https://github.com/ASFHyP3/hyp3-nasa-disasters/pull/67 added a `continue-on-error: true` line to continue to the transfer step after the process step times out while waiting for the hyp3 jobs to finish, but this had the unintended effect of also ignoring all other errors (e.g. unhandled exceptions) during the process step.

https://github.com/ASFHyP3/hyp3-nasa-disasters/pull/137 removed that line, but now we'll probably see the workflow start timing out again.

This PR just removes the `-w` flag from the `process_new_granules.py` command, which is what was responsible for running `hyp3.watch` in [`process_new_granules.py`](https://github.com/ASFHyP3/hyp3-nasa-disasters/blob/main/data_management/process_new_granules.py). Hopefully this will have the desired effect of allowing the transfer step to run without being blocked by the process step, *without* ignoring legitimate errors.