### PR TITLE
enable date-based partioning for s3 access logs

### DIFF
--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -45,6 +45,9 @@ Resources:
       LoggingConfiguration:
         DestinationBucketName: !Ref LogBucket
         LogFilePrefix: s3-access-logs/content-bucket/
+        TargetObjectKeyFormat:
+          PartitionedPrefix:
+            PartitionDateSource: EventTime
       LifecycleConfiguration:
         Rules:
           - Status: Enabled


### PR DESCRIPTION
Enabled date-based partitioning for S3 access log object keys to simplify log management going forward.

News post announcing the feature: https://aws.amazon.com/about-aws/whats-new/2023/11/amazon-s3-server-access-logging-date-partitioning/

Documentation: step #4 and "Log object key format" at https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerLogs.html